### PR TITLE
sdl-dingux: Request triple buffering if supported.

### DIFF
--- a/src/sdl-dingux/sdl_video.cpp
+++ b/src/sdl-dingux/sdl_video.cpp
@@ -1819,7 +1819,13 @@ void VideoTrans()
 int VideoInit()
 {
 	// Initialize SDL
-	int flags = (options.vsync ? SDL_HWSURFACE | SDL_DOUBLEBUF : SDL_SWSURFACE);
+	int flags = (options.vsync ? (SDL_HWSURFACE |
+#ifdef SDL_TRIPLEBUF
+		SDL_TRIPLEBUF
+#else
+		SDL_DOUBLEBUF
+#endif
+		) : SDL_SWSURFACE);
 
 	if(!(SDL_WasInit(SDL_INIT_VIDEO) & SDL_INIT_VIDEO)) {
 		SDL_InitSubSystem(SDL_INIT_VIDEO);


### PR DESCRIPTION
Triple buffering improves the performance of games that, were it not for the need to wait for one back buffer to be ready using double-buffering, could reach the correct frames per second with more CPU time allotted to the emulator.
