### PR TITLE
Update drv.cpp

### DIFF
--- a/src/sdl-dingux/drv.cpp
+++ b/src/sdl-dingux/drv.cpp
@@ -58,7 +58,9 @@ static int DrvLoadRom(unsigned char* Dest, int* pnWrote, int i)
 
 int DrvInit(int nDrvNum, bool bRestore)
 {
-	DrvExit();			// Make sure exitted
+	if (bDrvOkay) {
+		DrvExit();			// Make sure exitted
+	}
 	SndInit(); //AudSoundInit();	// Init Sound (not critical if it fails)
 
 	/*nBurnSoundRate = 0;		// Assume no sound


### PR DESCRIPTION
Prevent corruption of .cfg file when a rom is loaded via the command line. (It always saved the default config over the top of the .cfg file before loading the .cfg file.)

(Apologies, I may have changed the line-endings on a couple of other lines, sorry guys. CRLF whatever.)